### PR TITLE
Fixes account profile form

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "jest-emotion": "^10.0.32",
         "lint-staged": "^10.5.1",
         "prop-types": "^15.7.2",
+        "random-username-generator": "^1.0.4",
         "react": "^16.12.0",
         "react-avatar-editor": "11.0.9",
         "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "gatsby-fire-pro-default",
     "private": true,
     "description": "A simple starter to get up and developing quickly with Gatsby",
-    "version": "0.1.0",
-    "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+    "version": "0.1.2",
+    "author": "Marc Arbesman <marc@ninozfantasysports.com>",
     "dependencies": {
         "@apollo/client": "^3.2.5",
         "@devhammed/use-cookie": "^1.1.0",

--- a/src/components/AccountProfileForm/index.jsx
+++ b/src/components/AccountProfileForm/index.jsx
@@ -359,6 +359,22 @@ function AccountProfileForm() {
                                         <ErrorMessage>City must be at least 2 characters</ErrorMessage>
                                     </FormBox>
                                 )}
+                                <FormBox>
+                                    <InputField
+                                        register={register({ required: true, minLength: 5 })}
+                                        name="zip"
+                                        placeholder="zip"
+                                        type="text"
+                                        aria-label="Zip"
+                                        defaultValue={queryData && queryData?.zip}
+                                    />
+                                </FormBox>
+                                {errors?.lastName && errors?.zip?.type === 'minLength' && (
+                                    <FormBox>
+                                        <ErrorIcon />
+                                        <ErrorMessage>Zip must be at least 2 characters</ErrorMessage>
+                                    </FormBox>
+                                )}
 
                                 {queryData && isLoginProviderEmail() && (
                                     <FormBox>

--- a/src/components/AccountProfileForm/index.jsx
+++ b/src/components/AccountProfileForm/index.jsx
@@ -145,7 +145,6 @@ function AccountProfileForm() {
                 data: data2,
             },
         })
-        console.log('🚀 ~ file: index.jsx ~ line 147 ~ onSubmit ~ data2', data2)
     }
 
     const onFileChanged = (event) => {

--- a/src/components/Forms/FormFields/InputField/index.test.js
+++ b/src/components/Forms/FormFields/InputField/index.test.js
@@ -46,6 +46,10 @@ describe('InputField', () => {
               color: #FFF;
             }
 
+            .emotion-0:disabled {
+              color: #495358;
+            }
+
             <input
               aria-label="Last Name"
               className="emotion-0 emotion-1"

--- a/src/components/Forms/FormFields/InputField/styles.js
+++ b/src/components/Forms/FormFields/InputField/styles.js
@@ -32,4 +32,7 @@ export const InputFieldStyle = styled.input`
 		background: ${COLORS.SECONDARY_DARK};
 		color ${COLORS.PRIMARY};
 	}
+    &:disabled {
+        color: ${COLORS.TERNARY_DARK};
+    }
 `

--- a/src/components/LoginForm/index.jsx
+++ b/src/components/LoginForm/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { InputField, EmailSubmitButton } from 'components/Forms/FormFields'
+import * as Rug from 'random-username-generator'
 import {
     ButtonLabelWrapper,
     ButtonLabelIconBox,
@@ -22,7 +23,8 @@ import {
 } from 'components/Forms/FormLayout'
 import { navigate } from 'gatsby'
 import Loader from 'components/Loader'
-import { FIREBASE } from 'utils/constants'
+import { FIREBASE, LOGIN_PROVIDER } from 'utils/constants'
+import { defaultUserRegFields } from 'utils/userHelpers'
 import useFirebaseAuthentication from 'hooks/firebase/useFirebaseAuthentication'
 
 function LoginForm() {
@@ -52,7 +54,7 @@ function LoginForm() {
 
     const onGoogleSubmit = async (event) => {
         event.preventDefault()
-        onGoogleLogin()
+        onGoogleLogin({ ...defaultUserRegFields, loginProvider: LOGIN_PROVIDER.GOOGLE, username: Rug.generate() })
     }
 
     return (

--- a/src/components/RegisterForm/index.jsx
+++ b/src/components/RegisterForm/index.jsx
@@ -23,7 +23,7 @@ import {
     FormFlexInnerBox,
 } from 'components/Forms/FormLayout'
 import { FIREBASE } from 'utils/constants'
-import { getAvatarThemeIndex } from 'utils/userHelpers'
+import { defaultUserRegFields } from 'utils/userHelpers'
 import useFirebaseAuthentication from 'hooks/firebase/useFirebaseAuthentication'
 import Loader from 'components/Loader'
 
@@ -32,14 +32,6 @@ function RegisterForm() {
     const [hasGoogleRegistrationError, setHasGoogleRegistrationError] = useState(false)
     function onAuthenticationSuccess() {
         navigate('/account')
-    }
-
-    const defaultFields = {
-        defaultAvatarThemeIndex: getDefaultAvatarIndex(),
-        profileImageName: '',
-        city: '',
-        state: '',
-        zip: '',
     }
 
     const {
@@ -51,14 +43,7 @@ function RegisterForm() {
         onAuthenticationSuccess,
         firebaseConfig: FIREBASE.CONFIG,
     })
-    function getDefaultAvatarIndex() {
-        try {
-            const index = document.getElementsByName('defaultAvatarThemeIndex')[0]
-            return parseInt(index.value)
-        } catch (e) {
-            return 0
-        }
-    }
+
     const handleGoogleSubmit = async (event) => {
         event.preventDefault()
         const username = document.getElementsByName('username')[0]
@@ -69,7 +54,7 @@ function RegisterForm() {
         await onGoogleRegistration({
             username: username.value,
             loginProvider: 'google',
-            ...defaultFields,
+            ...defaultUserRegFields,
         })
         return
     }
@@ -79,7 +64,7 @@ function RegisterForm() {
         onEmailRegistration({
             ...restOfFormData,
             loginProvider: 'email',
-            ...defaultFields,
+            ...defaultUserRegFields,
         })
     }
     return (
@@ -228,12 +213,6 @@ function RegisterForm() {
                                         register={register({ validate: (value) => value === watch('password') })}
                                         type="password"
                                         aria-label="Confirm Password"
-                                    />
-                                    <input
-                                        type="hidden"
-                                        ref={register}
-                                        name="defaultAvatarThemeIndex"
-                                        defaultValue={getAvatarThemeIndex()}
                                     />
                                 </FormBox>
                                 {errors.confirmPassword && errors.confirmPassword.type === 'validate' && (

--- a/src/hooks/firebase/useFirebaseAuthentication.js
+++ b/src/hooks/firebase/useFirebaseAuthentication.js
@@ -168,8 +168,11 @@ function useFirebaseAuthentication({ onAuthenticationSuccess = null, firebaseCon
         }
     }
 
-    const onGoogleLogin = async () => {
+    const onGoogleLogin = async (data = null) => {
         try {
+            if (data) {
+                setUserProfileStorage({ ...data })
+            }
             setIsAuthenticationLoading(true)
             setLoginFlagStorage()
             await doSignInWithGoogle()
@@ -238,10 +241,6 @@ function useFirebaseAuthentication({ onAuthenticationSuccess = null, firebaseCon
                             firstName,
                             email,
                             lastName,
-                            city: '',
-                            state: '',
-                            zip: '',
-                            username: '',
                             ...userProfileData,
                         }
                         try {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,7 +13,6 @@ const FIREBASE = {
         messagingSenderId: process.env.GATSBY_MESSAGINGSENDERID,
     },
 }
-
 const ACCEPTED_IMAGE_FORMATS = ['.jpg', '.png', '.jpeg', '.gif']
 const AVATAR_IMAGE_SIZE = 80
 const AVATAR_IMAGE_SIZE_MEDIUM = 175

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -11,3 +11,18 @@ export const getInitials = ({ prefersUsername, username, firstName, lastName }) 
 }
 
 export const getAvatarThemeIndex = () => Math.floor(Math.random() * 3) + 0
+export function getDefaultAvatarIndex() {
+    try {
+        const index = document.getElementsByName('defaultAvatarThemeIndex')[0]
+        return parseInt(index.value)
+    } catch (e) {
+        return 0
+    }
+}
+export const defaultUserRegFields = {
+    defaultAvatarThemeIndex: getDefaultAvatarIndex(),
+    profileImageName: '',
+    city: '',
+    state: '',
+    zip: '',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14315,6 +14315,11 @@ randexp@0.4.6:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
 
+random-username-generator@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/random-username-generator/-/random-username-generator-1.0.4.tgz#05a3a62a497bef0cfaa7a850e7822b7969848a7b"
+  integrity sha1-BaOmKkl77wz6p6hQ54IreWmEins=
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
handles email disable field if logged in from a third party login provider.  If user registers from third party login provider (i.e. clicks google login without going through the register form), they will get a defaulted username that they can change later.  Centralizes default user data model for graphQL endpoint for both login and register